### PR TITLE
Feature/improve excel functions

### DIFF
--- a/mango/tests/test_file_functions.py
+++ b/mango/tests/test_file_functions.py
@@ -83,6 +83,13 @@ class FileTests(TestCase):
         self.assertIsInstance(data["Sheet1"], pd.DataFrame)
         self.assertEqual(data["Sheet1"].shape, (2, 2))
 
+    def test_excel_file_to_dict(self):
+        file = normalize_path("./data/test.xlsx")
+        data = load_excel(file, output="records")
+        self.assertIn("Sheet1", data.keys())
+        self.assertIsInstance(data["Sheet1"], list)
+        self.assertEqual(data["Sheet1"], [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])
+
     def test_write_excel(self):
         data = {
             "Sheet1": {"a": [1, 2, 3], "b": [4, 5, 6]},


### PR DESCRIPTION
- load_excel use dtype="object" as default in order to read values with the type they have in excel (not transform "01" into 1)
- add output argument in order to be able transform the data in list of dict.
- write excel accept data in DataFrames format.