### PR TITLE
fix for reading variables from xlsx file

### DIFF
--- a/mango/processing/file_functions.py
+++ b/mango/processing/file_functions.py
@@ -389,6 +389,8 @@ def load_str_iterable(v):
             return ast.literal_eval(v)
         except SyntaxError:
             return v
+        except ValueError:
+            return v
     else:
         return v
 

--- a/mango/processing/file_functions.py
+++ b/mango/processing/file_functions.py
@@ -364,7 +364,6 @@ def load_excel_light(path, sheets=None):
     dataset = {}
     for name, v in dict_sheets.items():
         data = [row for row in v]
-        print(data)
         if len(data):
             dataset[name] = (
                 TupList(data[1:])
@@ -380,6 +379,7 @@ def load_excel_light(path, sheets=None):
 def load_str_iterable(v):
     """
     Evaluate the value of an Excel cell and return strings representing python iterables as such.
+    Return other strings and other types unchanged.
 
     :param v: content of an Excel cell
     :return: value of the cell
@@ -387,9 +387,7 @@ def load_str_iterable(v):
     if isinstance(v, str):
         try:
             return ast.literal_eval(v)
-        except SyntaxError:
-            return v
-        except ValueError:
+        except (SyntaxError, ValueError):
             return v
     else:
         return v

--- a/mango/tests/processing_module/test_file_functions.py
+++ b/mango/tests/processing_module/test_file_functions.py
@@ -18,7 +18,7 @@ from mango.processing.file_functions import (
     load_csv_light,
     write_csv_light,
     load_excel_light,
-    write_excel_light,
+    write_excel_light, load_str_iterable,
 )
 from mango.tests.const import normalize_path
 
@@ -319,3 +319,32 @@ class FileTests(TestCase):
         data = {"a": [1, 2, 3], "b": [4, 5, 6]}
         file = normalize_path("./data/temp.xlsz")
         self.assertRaises(FileNotFoundError, write_csv, file, data)
+
+    def test_load_str_iterable(self):
+        """
+        load_str_iterable should transform string representing pythons objects
+        like lists and dict into the relevant object.
+        Other strings should be left unchanged.
+        """
+        expected = [1,2,3]
+        result = load_str_iterable("[1,2,3]")
+        self.assertEqual(expected, result)
+
+        expected = {1:2}
+        result = load_str_iterable("{1:2}")
+        self.assertEqual(expected, result)
+
+        expected = "column name"
+        result = load_str_iterable("column name")
+        self.assertEqual(expected, result)
+
+        expected = "12/11/2024"
+        result = load_str_iterable("12/11/2024")
+        self.assertEqual(expected, result)
+
+        expected = 12
+        result = load_str_iterable(12)
+        self.assertEqual(expected, result)
+
+
+

--- a/mango/tests/processing_module/test_file_functions.py
+++ b/mango/tests/processing_module/test_file_functions.py
@@ -12,13 +12,15 @@ from mango.processing import (
     write_json,
     load_csv,
     write_excel,
-    write_csv, pickle_copy,
+    write_csv,
+    pickle_copy,
 )
 from mango.processing.file_functions import (
     load_csv_light,
     write_csv_light,
     load_excel_light,
-    write_excel_light, load_str_iterable,
+    write_excel_light,
+    load_str_iterable,
 )
 from mango.tests.const import normalize_path
 
@@ -203,7 +205,7 @@ class FileTests(TestCase):
     def test_write_excel_light_iter(self):
         file = normalize_path("./data/temp.xlsx")
         data = pickle_copy(self.data_1)
-        data["Sheet1"] = [{'a': [1,2], "b":["a1", "a2"], "c": {"i":1}}]
+        data["Sheet1"] = [{"a": [1, 2], "b": ["a1", "a2"], "c": {"i": 1}}]
         write_excel_light(file, data)
 
         data2 = load_excel_light(file)
@@ -326,11 +328,11 @@ class FileTests(TestCase):
         like lists and dict into the relevant object.
         Other strings should be left unchanged.
         """
-        expected = [1,2,3]
+        expected = [1, 2, 3]
         result = load_str_iterable("[1,2,3]")
         self.assertEqual(expected, result)
 
-        expected = {1:2}
+        expected = {1: 2}
         result = load_str_iterable("{1:2}")
         self.assertEqual(expected, result)
 
@@ -345,6 +347,3 @@ class FileTests(TestCase):
         expected = 12
         result = load_str_iterable(12)
         self.assertEqual(expected, result)
-
-
-


### PR DESCRIPTION
The function instance_from_excel returns the error while reading model variables from excel file. The following commit should fix that issue