### PR TITLE
disable_existing_loggers to False

### DIFF
--- a/mango/mango/logging/logger.py
+++ b/mango/mango/logging/logger.py
@@ -262,7 +262,7 @@ HANDLERS = {
 
 LOGGING_DICT_DEFAULT = {
     "version": 1,
-    "disable_existing_loggers": True,
+    "disable_existing_loggers": False,
     "formatters": FORMATTERS,
     "handlers": HANDLERS,
     "loggers": {


### PR DESCRIPTION
Setting disable_existing_loggers to false in the Airflow logging configuration ensures that any previously configured loggers are not disabled when loading a new logging configuration. This is particularly important in Airflow.