### PR TITLE
Implement backwards pass functionality for RNN variants

### DIFF
--- a/mango_time_series/mango_time_series/models/autoencoder.py
+++ b/mango_time_series/mango_time_series/models/autoencoder.py
@@ -6,7 +6,7 @@ import numpy as np
 import tensorflow as tf
 from keras import Sequential
 from keras.src.optimizers import Adam
-from tensorflow.python.keras.models import load_model
+from tensorflow.keras.models import load_model
 
 from mango_time_series.models.losses import mean_squared_error
 from mango_time_series.models.modules import encoder, decoder

--- a/mango_time_series/mango_time_series/models/autoencoder.py
+++ b/mango_time_series/mango_time_series/models/autoencoder.py
@@ -6,7 +6,7 @@ import numpy as np
 import tensorflow as tf
 from keras import Sequential
 from keras.src.optimizers import Adam
-from tensorflow.keras.models import load_model
+from tensorflow.python.keras.models import load_model
 
 from mango_time_series.models.losses import mean_squared_error
 from mango_time_series.models.modules import encoder, decoder
@@ -17,20 +17,6 @@ from mango_time_series.models.utils.plots import (
 from mango_time_series.models.utils.sequences import time_series_to_sequence
 
 logger = logging.getLogger(__name__)
-
-
-# TODO: Current implementation checks one input variable for reconstruction error.
-#   Change to pass a list of indexes.
-# TODO: Current implementation gives the same weight to all input variables for
-#  the reconstruction error. Maybe we want to be able to set up different
-#  weights for each input variable.
-# TODO: Current implementation just can check one timestep for reconstruction
-#   error. Maybe we want to check the last n or something like that
-# TODO: implement backwards pass for RNN, LSTM and GRU.
-# TODO: implement early stopping criteria
-# TODO: min and max values should be stored with model weights somehow. We should
-#  have a class method to load the model before doing inference.
-# TODO: maybe add some dense layer after the decoder in order to have the final compression go more smoothly
 
 
 class AutoEncoder:
@@ -50,6 +36,8 @@ class AutoEncoder:
         feature_to_check: Union[int, List[int]] = 0,
         num_layers: int = None,
         hidden_dim: Union[int, List[int]] = None,
+        bidirectional_encoder: bool = False,
+        bidirectional_decoder: bool = False,
         normalize: bool = True,
         batch_size: int = 32,
         split_size: float = 0.7,
@@ -79,7 +67,7 @@ class AutoEncoder:
           of the context window to check. In the future this could be a list of
           indices to check. For taking only the last timestep of the context
           window this should be set to -1.
-        :type timesteps_to_check: Union[int, List[int]]
+        :type time_step_to_check: Union[int, List[int]]
         :param num_layers: number of internal layers. This number is used to
           know the number of encoding layers after the input (the result of
           the last layer is going to be the embedding of the autoencoder) and
@@ -90,6 +78,12 @@ class AutoEncoder:
           It can be a single integer (same for all layers) or a list of
           dimensions for each layer.
         :type hidden_dim: Union[int, List[int]]
+        :param bidirectional_encoder: whether to use bidirectional LSTM in the
+            encoder part of the model.
+        :type bidirectional_encoder: bool
+        :param bidirectional_decoder: whether to use bidirectional LSTM in the
+            decoder part of the model.
+        :type bidirectional_decoder: bool
         :param normalize: whether to normalize the data or not.
         :type normalize: bool
         :param batch_size: batch size for the model
@@ -139,6 +133,22 @@ class AutoEncoder:
                 "Data must be a numpy array or a tuple with three numpy arrays"
             )
 
+        bidirectional_allowed = {"lstm", "gru", "rnn"}
+
+        if form not in bidirectional_allowed:
+            if bidirectional_encoder and bidirectional_decoder:
+                raise ValueError(
+                    f"Bidirectional is not supported for encoder and decoder type '{form}'."
+                )
+            elif bidirectional_encoder:
+                raise ValueError(
+                    f"Bidirectional is not supported for encoder type '{form}'."
+                )
+            elif bidirectional_decoder:
+                raise ValueError(
+                    f"Bidirectional is not supported for decoder type '{form}'."
+                )
+
         self.prepare_datasets(data, context_window, normalize, split_size)
 
         if isinstance(feature_to_check, int):
@@ -157,6 +167,9 @@ class AutoEncoder:
         test_dataset = tf.data.Dataset.from_tensor_slices(self.x_test)
         test_dataset = test_dataset.cache().batch(batch_size)
 
+        self.bidirectional_encoder = bidirectional_encoder
+        self.bidirectional_decoder = bidirectional_decoder
+
         model = Sequential(
             [
                 encoder(
@@ -165,6 +178,7 @@ class AutoEncoder:
                     features=self.input_features,
                     hidden_dim=hidden_dim,
                     num_layers=num_layers,
+                    use_bidirectional=self.bidirectional_encoder,
                     verbose=verbose,
                 ),
                 decoder(
@@ -173,6 +187,7 @@ class AutoEncoder:
                     features=self.output_features,
                     hidden_dim=hidden_dim,
                     num_layers=num_layers,
+                    use_bidirectional=self.bidirectional_decoder,
                     verbose=verbose,
                 ),
             ],

--- a/mango_time_series/mango_time_series/models/modules/decoder.py
+++ b/mango_time_series/mango_time_series/models/modules/decoder.py
@@ -2,7 +2,7 @@ import logging as log
 from typing import Union, List
 
 from keras import Input, Model
-from keras.src.layers import LSTM, Dense, Flatten, SimpleRNN, GRU
+from keras.src.layers import LSTM, Dense, Flatten, SimpleRNN, GRU, Bidirectional
 
 logger = log.getLogger(__name__)
 
@@ -82,6 +82,7 @@ def _decoder_lstm(
     features: int,
     hidden_dim: Union[int, List[int]],
     num_layers: int,
+    use_bidirectional: bool = False,
     verbose: bool = False,
 ) -> Model:
     """
@@ -96,6 +97,8 @@ def _decoder_lstm(
     :type hidden_dim: Union[int, List[int]]
     :param num_layers: number of LSTM layers
     :type num_layers: int
+    :param use_bidirectional: whether to use bidirectional LSTM
+    :type use_bidirectional: bool
     :param verbose: whether to print the model summary
     :type verbose: bool
     :return: LSTM decoder model
@@ -114,10 +117,15 @@ def _decoder_lstm(
     input_layer = Input((context_window, hidden_dim[0]))
 
     for i in range(num_layers):
-        layer = LSTM(
+        lstm_layer = LSTM(
             hidden_dim[i],
             return_sequences=True,
-        )(input_layer if i == 0 else layer)
+        )
+
+        if use_bidirectional:
+            layer = Bidirectional(lstm_layer)(input_layer if i == 0 else layer)
+        else:
+            layer = lstm_layer(input_layer if i == 0 else layer)
 
     flatten = Flatten()(layer)
     output_layer = Dense(features)(flatten)
@@ -134,6 +142,7 @@ def _decoder_gru(
     features: int,
     hidden_dim: Union[int, List[int]],
     num_layers: int,
+    use_bidirectional: bool = False,
     verbose: bool = False,
 ) -> Model:
     """
@@ -148,6 +157,8 @@ def _decoder_gru(
     :type hidden_dim: Union[int, List[int]]
     :param num_layers: number of GRU layers
     :type num_layers: int
+    :param use_bidirectional: whether to use bidirectional GRU
+    :type use_bidirectional: bool
     :param verbose: whether to print the model summary
     :type verbose: bool
     :return: GRU decoder model
@@ -166,10 +177,14 @@ def _decoder_gru(
     input_layer = Input((context_window, hidden_dim[0]))
 
     for i in range(num_layers):
-        layer = GRU(
+        gru_layer = GRU(
             hidden_dim[i],
             return_sequences=True,
-        )(input_layer if i == 0 else layer)
+        )
+        if use_bidirectional:
+            layer = Bidirectional(gru_layer)(input_layer if i == 0 else layer)
+        else:
+            layer = gru_layer(input_layer if i == 0 else layer)
 
     flatten = Flatten()(layer)
     output_layer = Dense(features)(flatten)
@@ -186,6 +201,7 @@ def _decoder_rnn(
     features: int,
     hidden_dim: Union[int, List[int]],
     num_layers: int,
+    use_bidirectional: bool = False,
     verbose: bool = False,
 ) -> Model:
     """
@@ -200,6 +216,8 @@ def _decoder_rnn(
     :type hidden_dim: Union[int, List[int]]
     :param num_layers: number of RNN layers
     :type num_layers: int
+    :param use_bidirectional: whether to use bidirectional RNN
+    :type use_bidirectional: bool
     :param verbose: whether to print the model summary
     :type verbose: bool
     :return: RNN decoder model
@@ -218,10 +236,14 @@ def _decoder_rnn(
     input_layer = Input((context_window, hidden_dim[0]))
 
     for i in range(num_layers):
-        layer = SimpleRNN(
+        rnn_layer = SimpleRNN(
             hidden_dim[i],
             return_sequences=True,
-        )(input_layer if i == 0 else layer)
+        )
+        if use_bidirectional:
+            layer = Bidirectional(rnn_layer)(input_layer if i == 0 else layer)
+        else:
+            layer = rnn_layer(input_layer if i == 0 else layer)
 
     flatten = Flatten()(layer)
     output_layer = Dense(features)(flatten)


### PR DESCRIPTION
This update enhances the autoencoder by adding support for bidirectional LSTM, GRU, and RNN layers (forward and backward pass). `bidirectional_encoder `and `bidirectional_decoder `can be enabled separately or together, but only for recurrent architectures. A validation step prevents their use in non-recurrent models like dense, raising a ValueError when necessary. Resolves #175 