### PR TITLE
Handle conditional import for `DataImputer`  

### DIFF
--- a/mango/mango/processing/__init__.py
+++ b/mango/mango/processing/__init__.py
@@ -17,7 +17,27 @@ from .file_functions import (
     is_excel_file,
     is_json_file,
 )
-from .data_imputer import DataImputer
+
+try:
+    from .data_imputer import DataImputer
+except ImportError:
+
+    class DataImputer:
+        """
+        Placeholder for DataImputer when dependencies are missing.
+
+        :raises ImportError: When instantiated without required dependencies
+        """
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                f"""
+                DataImputer requires 'sklearn' and 'polars'.
+                Install them with `pip install mango[data]` to use this module.
+                """
+            )
+
+
 from .object_functions import (
     pickle_copy,
     unique,


### PR DESCRIPTION
- Wrapped `DataImputer` import in a `try-except` block to prevent module import failure if `sklearn` or `polars` are missing.  
- Added a placeholder `DataImputer` class that raises an `ImportError` only when instantiated.  
- Provides a clear installation message: `pip install mango[data]`.  

This ensures the package can be imported even if the dependencies are not installed.