### PR TITLE
Remove deprecated argument as now is done by default

### DIFF
--- a/mango_time_series/mango_time_series/tests/cli_module/test_cli.py
+++ b/mango_time_series/mango_time_series/tests/cli_module/test_cli.py
@@ -34,7 +34,7 @@ class TestCli(TestCase):
 
     @mock.patch("os.system")
     def test_cli_default(self, mock_system):
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
         result = runner.invoke(cli, ["dashboard", "time_series"])
 
         # Assert the command executed successfully


### PR DESCRIPTION
Click library deprecated an argument used in testing. Removed it because it now does it by default.

@gvalleg can you check how requirements for this works? At the moment it just kinda of works by pure luck.