### PR TITLE
Add individual PyPI tokens for mango libraries

### DIFF
--- a/.github/workflows/mango_autoencoder_publish_to_pypi.yml
+++ b/.github/workflows/mango_autoencoder_publish_to_pypi.yml
@@ -29,5 +29,5 @@ jobs:
         working-directory: mango_autoencoder
 
       - name: Publish to PyPI
-        run: uv publish --token ${{ secrets.PYPI_TOKEN }} dist/*
+        run: uv publish --token ${{ secrets.PYPI_AUTOENCODER_TOKEN }} dist/*
         working-directory: mango_autoencoder

--- a/.github/workflows/mango_dashboard_publish_to_pypi.yml
+++ b/.github/workflows/mango_dashboard_publish_to_pypi.yml
@@ -29,5 +29,5 @@ jobs:
         working-directory: mango_dashboard
 
       - name: Publish to PyPI
-        run: uv publish --token ${{ secrets.PYPI_TOKEN }} dist/*
+        run: uv publish --token ${{ secrets.PYPI_DASHBOARD_TOKEN }} dist/*
         working-directory: mango_dashboard

--- a/.github/workflows/mango_genetic_publish_to_pypi.yml
+++ b/.github/workflows/mango_genetic_publish_to_pypi.yml
@@ -29,6 +29,6 @@ jobs:
         working-directory: mango_genetic
 
       - name: Publish to PyPI
-        run: uv publish --token ${{ secrets.PYPI_TOKEN }} dist/*
+        run: uv publish --token ${{ secrets.PYPI_GENETIC_TOKEN }} dist/*
         working-directory: mango_genetic
 


### PR DESCRIPTION
Added specific PyPI tokens for each mango library to enable proper releases.

**Before**: Generic tokens for initial library creation
**After**: Individual tokens for each library (autoencoder, dashboard, genetic)
