### PR TITLE
hotfix: Fix PyPI publishing and documentation build with uv

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,7 @@ jobs:
     # Build documentation
     - name: Build HTML docs
       working-directory: docs
-      run: make html
+      run: uv run make html
     
     # Publish built docs to gh-pages branch
     - name: Commit documentation changes

--- a/.github/workflows/mango_autoencoder_publish_to_pypi.yml
+++ b/.github/workflows/mango_autoencoder_publish_to_pypi.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/autoencoder')
 
     steps:
       - name: Check out repository

--- a/.github/workflows/mango_base_publish_to_pypi.yml
+++ b/.github/workflows/mango_base_publish_to_pypi.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/mango')
 
     steps:
       - name: Check out repository

--- a/.github/workflows/mango_calendar_publish_to_pypi.yml
+++ b/.github/workflows/mango_calendar_publish_to_pypi.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/calendar')
 
     steps:
       - name: Check out repository

--- a/.github/workflows/mango_dashboard_publish_to_pypi.yml
+++ b/.github/workflows/mango_dashboard_publish_to_pypi.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/dashboard')
 
     steps:
       - name: Check out repository

--- a/.github/workflows/mango_genetic_publish_to_pypi.yml
+++ b/.github/workflows/mango_genetic_publish_to_pypi.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/genetic')
 
     steps:
       - name: Check out repository

--- a/.github/workflows/mango_time_series_publish_to_pypi.yml
+++ b/.github/workflows/mango_time_series_publish_to_pypi.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/ts')
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
This hotfix resolves two critical issues with the uv-based architecture: documentation generation failures and PyPI publishing workflow problems. 

- For documentation, the fix addresses the "sphinx-build: not found" error by implementing proper uv environment activation in the build process. 
- For PyPI publishing, the fix corrects workflow configurations to ensure packages are built and published correctly using uv instead of pip. 