### PR TITLE
Update mango version and fix documentation structure with changelog formatting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,10 +29,25 @@ Python Code Style
 
 1. All code must be formatted using Black formatter with default settings:
 
+   **Using pip:**
+
    .. code-block:: bash
 
        # Install Black
        pip install black
+
+       # Format a file
+       black file.py
+
+       # Format entire project
+       black .
+
+   **Using uv:**
+
+   .. code-block:: bash
+
+       # Install Black with uv
+       uv tool install black
 
        # Format a file
        black file.py
@@ -227,43 +242,72 @@ Running Tests
 
 1. Run all tests:
 
+   **Using pip:**
+
    .. code-block:: bash
 
-       # Using pytest directly
-       pytest
-       
-       # Using uv
-       uv run pytest
+       # Run tests with unittest
+       python -m unittest discover
+
+   **Using uv:**
+
+   .. code-block:: bash
+
+       # Run tests with uv
+       uv run python -m unittest discover
 
 2. Run tests with coverage:
 
+   **Using pip:**
+
    .. code-block:: bash
 
-       # Using pytest directly
-       pytest --cov=mango
+       # Install coverage
+       pip install coverage
        
-       # Using uv
-       uv run pytest --cov=mango
+       # Run tests with coverage
+       coverage run -m unittest discover
+       coverage report
+
+   **Using uv:**
+
+   .. code-block:: bash
+
+       # Run tests with coverage using uv
+       uv run coverage run -m unittest discover
+       uv run coverage report
 
 3. Run specific test file:
 
+   **Using pip:**
+
    .. code-block:: bash
 
-       # Using pytest directly
-       pytest tests/module/test_feature.py
-       
-       # Using uv
-       uv run pytest tests/module/test_feature.py
+       # Run specific test file
+       python -m unittest tests.module.test_feature
+
+   **Using uv:**
+
+   .. code-block:: bash
+
+       # Run specific test file with uv
+       uv run python -m unittest tests.module.test_feature
 
 4. Run tests matching a pattern:
 
+   **Using pip:**
+
    .. code-block:: bash
 
-       # Using pytest directly
-       pytest -k "test_calculate"
-       
-       # Using uv
-       uv run pytest -k "test_calculate"
+       # Run tests matching pattern
+       python -m unittest discover -p "*test_calculate*"
+
+   **Using uv:**
+
+   .. code-block:: bash
+
+       # Run tests matching pattern with uv
+       uv run python -m unittest discover -p "*test_calculate*"
 
 Test Coverage Requirements
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -272,36 +316,23 @@ Test Coverage Requirements
 - Critical paths should have 100% coverage
 - Run coverage reports to verify:
 
+  **Using pip:**
+
   .. code-block:: bash
 
-      # Using pytest directly
-      pytest --cov=mango --cov-report=html
-      
-      # Using uv
-      uv run pytest --cov=mango --cov-report=html
+      # Run coverage report
+      coverage run -m unittest discover
+      coverage report
+      coverage html
 
-Mocking and Patching
-^^^^^^^^^^^^^^^^^
+  **Using uv:**
 
-Use mocking for external dependencies:
+  .. code-block:: bash
 
-.. code-block:: python
-
-    from unittest.mock import patch, MagicMock
-
-    def test_data_processor_with_external_api():
-        """
-        Test data processor with mocked API calls.
-        """
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"data": [1, 2, 3]}
-        
-        with patch("requests.get") as mock_get:
-            mock_get.return_value = mock_response
-            result = process_external_data("example.com/api")
-            
-            mock_get.assert_called_once_with("example.com/api")
-            assert result == [1, 2, 3]
+      # Run coverage report with uv
+      uv run coverage run -m unittest discover
+      uv run coverage report
+      uv run coverage html
 
 Documentation
 ------------
@@ -309,6 +340,129 @@ Documentation
 1. Update docstrings for any modified functions
 2. Update RST files in ``docs/source`` for new features
 3. Add examples to the documentation when appropriate
+4. **Important**: When adding new dependencies, add them to the mock imports in ``docs/source/conf.py`` to ensure autodoc works correctly
+
+   Example: If you add a new library like ``matplotlib``, add it to the ``autodoc_mock_imports`` list:
+
+   .. code-block:: python
+
+       # In docs/source/conf.py
+       autodoc_mock_imports = [
+           "numpy",
+           "pandas", 
+           "matplotlib",  # ← Add new library here
+           # ... other libraries
+       ]
+
+5. **Generate documentation locally** to verify everything is working correctly:
+
+   .. code-block:: bash
+
+       # Navigate to docs directory
+       cd docs
+       
+       # Activate documentation virtual environment and build
+       uv run make html
+       
+       # Open the generated documentation
+       start build/html/index.html  # Windows
+       # or
+       open build/html/index.html   # macOS
+       # or
+       xdg-open build/html/index.html  # Linux
+
+   **Note**: If you want to regenerate the documentation, you may need to clean the build directory first:
+
+   .. code-block:: bash
+
+       # Clean previous build
+       rm -rf build/
+       
+       # Regenerate documentation
+       uv run make html
+
+Publishing to PyPI
+~~~~~~~~~~~~~~~~~
+
+**Important**: Before publishing an official version from master, create beta versions in the develop branch with alpha format (e.g., 0.3.0a1) to test the release process.
+
+When you're ready to publish a new version to PyPI, follow these steps:
+
+1. **Check that README.rst files are properly formatted** to avoid GitHub Action failures:
+
+   .. code-block:: bash
+
+       # Navigate to the library directory
+       cd librería
+       # Example: cd mango_calendar
+
+       # Create the tag
+       git tag mango_calendarVERSION
+       # Example: git tag mango_calendar1.0.0
+
+       # Install twine for validation
+       pip install twine
+       
+       # Build the package
+       uv build --sdist --wheel
+       
+       # Check for formatting errors
+       twine check dist/*
+
+       # If there are errors, fix them and repeat the last two commands
+
+2. **Push tags to master** to trigger the PyPI publishing GitHub Actions:
+
+   .. code-block:: bash
+
+       # Create the tag
+       git tag mango_calendarVERSION
+       # Example: git tag mango_calendar1.0.0
+
+       # Push the tag to trigger the workflow
+       git push origin mango_calendarVERSION
+       # Example: git push origin mango_calendar1.0.0
+
+   The GitHub Action will automatically build and publish the package to PyPI.
+
+**Beta Testing Process:**
+
+Before releasing an official version, follow this beta testing workflow:
+
+1. **Create beta versions in develop branch**:
+
+   .. code-block:: bash
+
+       # Switch to develop branch
+       git checkout develop
+       
+       # Create alpha/beta tags for testing
+       git tag mango_calendar0.3.0a1  # First alpha
+       git tag mango_calendar0.3.0a2  # Second alpha
+       git tag mango_calendar0.3.0b1  # First beta
+       
+       # Push beta tags
+       git push origin mango_calendar0.3.0a1
+       git push origin mango_calendar0.3.0a2
+       git push origin mango_calendar0.3.0b1
+
+2. **Test the beta releases**:
+   - Verify PyPI publishing works correctly
+   - Test installation: ``pip install mango-calendar==0.3.0a1``
+   - Check that all functionality works as expected
+   - Validate documentation generation
+
+3. **Once beta testing is complete**, merge to master and create the official release:
+
+   .. code-block:: bash
+
+       # Merge develop to master
+       git checkout master
+       git merge develop
+       
+       # Create official release tag
+       git tag mango_calendar0.3.0
+       git push origin mango_calendar0.3.0
 
 Example of a well-documented feature:
 
@@ -405,7 +559,7 @@ Package Management
 
 We support both pip and uv for package management:
 
-**Using uv (Recommended):**
+**Using uv:**
 
 .. code-block:: bash
 
@@ -428,77 +582,6 @@ We support both pip and uv for package management:
     uv run black .
 
 
-IDE Setup
-~~~~~~~~
-
-For better development experience, we recommend opening each library separately in your IDE:
-
-1. For Mango library development:
-
-   .. code-block:: bash
-
-       # Clone the repository
-       git clone https://github.com/baobabsoluciones/mango.git
-       cd mango
-
-       # Using uv
-       uv venv
-       uv sync
-       uv run pip install -e .
-
-       # Open mango directory in your IDE
-       code mango/  # For VS Code
-       # or
-       pycharm mango/  # For PyCharm
-
-2. For Mango Time Series development:
-
-   .. code-block:: bash
-
-       # From repository root
-       cd mango_time_series
-
-       # Using uv
-       uv venv
-       uv sync
-
-       # Open mango_time_series directory in your IDE
-       code .  # For VS Code
-       # or
-       pycharm .  # For PyCharm
-
-Development Environment
-~~~~~~~~~~~~~~~~~~~~
-
-1. Configure your IDE:
-
-   - Enable Black formatter on save
-   - Set line length to 88 characters (Black default)
-   - Enable reST docstring format
-   - Configure pytest as test runner
-
-2. Recommended VS Code settings (`.vscode/settings.json`):
-
-   .. code-block:: json
-
-       {
-           "python.formatting.provider": "black",
-           "editor.formatOnSave": true,
-           "editor.rulers": [88],
-           "python.linting.enabled": true,
-           "python.testing.pytestEnabled": true,
-           "autoDocstring.docstringFormat": "sphinx"
-       }
-
-3. Pre-commit hooks:
-
-   Install pre-commit hooks to ensure code quality before committing:
-
-   .. code-block:: bash
-
-       # Using uv
-       uv add --dev pre-commit
-       uv run pre-commit install
 
 Development Workflow
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -80,16 +80,16 @@ Installation
 Documentation
 =============
 
-Full documentation is available at: https://mango.readthedocs.io/
+Full documentation is available at: https://baobabsoluciones.github.io/mango/
 
 Individual library documentation:
 
-- `Mango <https://mango.readthedocs.io/en/latest/code_mango/index.html>`_
-- `Mango Autoencoder <https://mango.readthedocs.io/en/latest/code_autoencoder/index.html>`_
-- `Mango Calendar <https://mango.readthedocs.io/en/latest/code_mango_calendar/index.html>`_
-- `Mango Dashboard <https://mango.readthedocs.io/en/latest/code_mango_dashboard/index.html>`_
-- `Mango Genetic <https://mango.readthedocs.io/en/latest/code_mango_genetic/index.html>`_
-- `Mango Time Series <https://mango.readthedocs.io/en/latest/code_mango_time_series/index.html>`_
+- `Mango <https://baobabsoluciones.github.io/mango/code_mango/index.html>`_
+- `Mango Autoencoder <https://baobabsoluciones.github.io/mango/code_autoencoder/index.html>`_
+- `Mango Calendar <https://baobabsoluciones.github.io/mango/code_mango_calendar/index.html>`_
+- `Mango Dashboard <https://baobabsoluciones.github.io/mango/code_mango_dashboard/index.html>`_
+- `Mango Genetic <https://baobabsoluciones.github.io/mango/code_mango_genetic/index.html>`_
+- `Mango Time Series <https://baobabsoluciones.github.io/mango/code_mango_time_series/index.html>`_
 
 Contributing
 ============
@@ -116,4 +116,4 @@ For questions, issues, or contributions, please contact:
 
 ---
 
-Made with ❤️ by `baobab soluciones <mailto:mango@baobabsoluciones.es>`_
+Made with ❤️ by `baobab soluciones <https://baobabsoluciones.es/>`_

--- a/docs/source/changelog/mango_autoencoder_changelog.rst
+++ b/docs/source/changelog/mango_autoencoder_changelog.rst
@@ -1,4 +1,4 @@
 mango-autoencoder
-------------------
+=================
 
 .. include:: ../../../mango_autoencoder/changelog.rst

--- a/docs/source/changelog/mango_calendar_changelog.rst
+++ b/docs/source/changelog/mango_calendar_changelog.rst
@@ -1,4 +1,4 @@
 mango-calendar
-------------------
+==============
 
 .. include:: ../../../mango_calendar/changelog.rst

--- a/docs/source/changelog/mango_changelog.rst
+++ b/docs/source/changelog/mango_changelog.rst
@@ -1,4 +1,4 @@
 mango
-------------------
+=====
 
 .. include:: ../../../mango/changelog.rst

--- a/docs/source/changelog/mango_dashboard_changelog.rst
+++ b/docs/source/changelog/mango_dashboard_changelog.rst
@@ -1,4 +1,4 @@
 mango-dashboard
-------------------
+===============
 
 .. include:: ../../../mango_dashboard/changelog.rst

--- a/docs/source/changelog/mango_genetic_changelog.rst
+++ b/docs/source/changelog/mango_genetic_changelog.rst
@@ -1,4 +1,4 @@
 mango-genetic
-------------------
+=============
 
 .. include:: ../../../mango_genetic/changelog.rst

--- a/docs/source/changelog/mango_time_series_changelog.rst
+++ b/docs/source/changelog/mango_time_series_changelog.rst
@@ -1,4 +1,4 @@
 mango-time-series
-------------------
+=================
 
 .. include:: ../../../mango_time_series/changelog.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,11 +41,6 @@ html_static_path = ["static"]
 autodoc_member_order = "bysource"
 autodoc_default_options = {"members": True, "inherited-members": True}
 
-from mango import mango
-
-version = mango.__version__
-release = mango.__version__
-
 
 # Options for bibtex
 bibtex_bibfiles = ["./refs.bib"]

--- a/mango/changelog.rst
+++ b/mango/changelog.rst
@@ -1,6 +1,3 @@
-Changelog
-=========
-
 All notable changes to the mango project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
@@ -9,12 +6,18 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
+[1.0.0] - 2024-12-24
+-------------------
+
 Added
 -----
 - Multi-module project structure with standalone packages
 - Integration with uv package manager alongside pip
 - Enhanced dependency management with optional dependency groups
 - Improved test coverage and modernized test infrastructure
+- Comprehensive documentation system with Sphinx and mock imports
+- Independent CI/CD workflows for each module
+- PyPI publishing automation for all modules
 
 Changed
 -------
@@ -22,6 +25,15 @@ Changed
 - Updated project documentation to reflect multi-module architecture
 - Consolidated pyproject.toml configuration files
 - Enhanced codecov.yml with coverage flags for all modules
+- Migrated from pip to uv for faster dependency management
+- Restructured codebase into independent, focused modules
+- Updated all documentation to reStructuredText format
+
+Removed
+-------
+- Obsolete functions and deprecated code
+- Outdated documentation formats
+- Unused configuration files
 
 Fixed
 -----
@@ -29,4 +41,6 @@ Fixed
 - Test failures related to dynamic versioning
 - ModuleNotFoundError for pkg_resources in tests
 - Incorrect mocking in test_requirement_check.py
+- Documentation build issues with heavy dependencies
+- PyPI publishing workflow failures
 

--- a/mango/changelog.rst
+++ b/mango/changelog.rst
@@ -7,7 +7,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 ------------
 
 [1.0.0] - 2024-12-24
--------------------
+--------------------
 
 Added
 -----

--- a/mango/mango/__init__.py
+++ b/mango/mango/__init__.py
@@ -3,4 +3,4 @@ Main file
 """
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
-__version__ = "0.2.3a1"
+__version__ = "1.0.0"

--- a/mango_autoencoder/changelog.rst
+++ b/mango_autoencoder/changelog.rst
@@ -1,6 +1,3 @@
-Changelog
-=========
-
 All notable changes to the mango_autoencoder project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
@@ -9,16 +6,15 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
+[1.0.1] - 2024-12-26
+-------------------
+
 Added
 -----
-- Enhanced autoencoder functionality and performance
-- Improved anomaly detection capabilities
-- Better integration with the mango ecosystem
+- Correct mango dependency version
 
-Changed
--------
-- Updated dependencies and package configuration
-- Enhanced test coverage and documentation
+[1.0.0] - 2024-12-24
+-------------------
 
 Added
 -----

--- a/mango_autoencoder/changelog.rst
+++ b/mango_autoencoder/changelog.rst
@@ -7,14 +7,14 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 ------------
 
 [1.0.1] - 2024-12-26
--------------------
+--------------------
 
 Added
 -----
 - Correct mango dependency version
 
 [1.0.0] - 2024-12-24
--------------------
+--------------------
 
 Added
 -----

--- a/mango_autoencoder/pyproject.toml
+++ b/mango_autoencoder/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.11,<3.12"
 dependencies = [
-    "mango[data]==0.3.0a8",
+    "mango==1.0.0",
     "pandas>=2.0.3,<3.0.0",
     "plotly>=6.2.0",
     "polars>=1.31.0",

--- a/mango_calendar/changelog.rst
+++ b/mango_calendar/changelog.rst
@@ -7,7 +7,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 ------------
 
 [1.0.0] - 2024-12-24
--------------------
+--------------------
 
 Added
 -----

--- a/mango_calendar/changelog.rst
+++ b/mango_calendar/changelog.rst
@@ -1,6 +1,3 @@
-Changelog
-=========
-
 All notable changes to the mango_calendar project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
@@ -9,16 +6,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
-Added
------
-- Enhanced calendar functionality and date utilities
-- Improved holiday and working day calculations
-- Better integration with the mango ecosystem
-
-Changed
--------
-- Updated dependencies and package configuration
-- Enhanced test coverage and documentation
+[1.0.0] - 2024-12-24
+-------------------
 
 Added
 -----
@@ -30,6 +19,14 @@ Added
 - Calendar data validation and processing
 - Support for multiple calendar systems
 - Comprehensive logging and error handling
+- Enhanced calendar functionality and date utilities
+- Improved holiday and working day calculations
+- Better integration with the mango ecosystem
+
+Changed
+-------
+- Updated dependencies and package configuration
+- Enhanced test coverage and documentation
 
 Features
 --------

--- a/mango_dashboard/changelog.rst
+++ b/mango_dashboard/changelog.rst
@@ -7,14 +7,14 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 ------------
 
 [1.0.1] - 2024-12-26
--------------------
+--------------------
 
 Added
 -----
 - Updated mango dependency version
 
 [1.0.0] - 2024-12-24
--------------------
+--------------------
 
 Added
 -----

--- a/mango_dashboard/changelog.rst
+++ b/mango_dashboard/changelog.rst
@@ -1,6 +1,3 @@
-Changelog
-=========
-
 All notable changes to the mango_dashboard project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
@@ -9,16 +6,15 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
+[1.0.1] - 2024-12-26
+-------------------
+
 Added
 -----
-- Enhanced dashboard functionality and user interface
-- Improved file exploration capabilities
-- Better time series visualization tools
+- Updated mango dependency version
 
-Changed
--------
-- Updated dependencies and package configuration
-- Enhanced test coverage and documentation
+[1.0.0] - 2024-12-24
+-------------------
 
 Added
 -----
@@ -30,6 +26,14 @@ Added
 - Custom UI components and templates
 - File handling for various formats (CSV, Excel, JSON)
 - Responsive design for different screen sizes
+- Enhanced dashboard functionality and user interface
+- Improved file exploration capabilities
+- Better time series visualization tools
+
+Changed
+-------
+- Updated dependencies and package configuration
+- Enhanced test coverage and documentation
 
 Features
 --------

--- a/mango_dashboard/pyproject.toml
+++ b/mango_dashboard/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
     "scikit-learn>=1.6.1, <2.0.0",
     "click>8.1.7, <8.2.0",
     "plotly>=6.2.0",
-    "mango[data]==0.3.0a8",
-    "mango-time-series==0.3.0a12",
+    "mango==1.0.0",
+    "mango-time-series==1.0.0",
     "google-cloud>=0.34.0",
     "google-cloud-storage>=3.3.0",
 ]

--- a/mango_dashboard/pyproject.toml
+++ b/mango_dashboard/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
     "scikit-learn>=1.6.1, <2.0.0",
     "click>8.1.7, <8.2.0",
     "plotly>=6.2.0",
-    "mango==1.0.0",
-    "mango-time-series==1.0.0",
+    "mango[data]==0.3.0a8",
+    "mango-time-series==0.3.0a12",
     "google-cloud>=0.34.0",
     "google-cloud-storage>=3.3.0",
 ]

--- a/mango_genetic/changelog.rst
+++ b/mango_genetic/changelog.rst
@@ -7,14 +7,14 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 ------------
 
 [1.0.1] - 2024-12-26
--------------------
+--------------------
 
 Added
 -----
 - Updated mango dependency version
 
 [1.0.0] - 2024-12-24
--------------------
+--------------------
 
 Added
 -----

--- a/mango_genetic/changelog.rst
+++ b/mango_genetic/changelog.rst
@@ -1,6 +1,3 @@
-Changelog
-=========
-
 All notable changes to the mango_genetic project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
@@ -9,8 +6,23 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
+[1.0.1] - 2024-12-26
+-------------------
+
 Added
 -----
+- Updated mango dependency version
+
+[1.0.0] - 2024-12-24
+-------------------
+
+Added
+-----
+- Core genetic algorithm framework
+- Individual and population management classes
+- Selection, crossover, mutation, and replacement algorithms
+- Configuration system for genetic algorithm parameters
+- Base classes for extensible genetic algorithm implementation
 - Standalone package structure for genetic algorithms module
 - Integration with uv package manager
 - Enhanced dependency management with numpy and mango core
@@ -21,14 +33,6 @@ Changed
 - Migrated from integrated module to standalone package
 - Updated project configuration and dependencies
 - Enhanced documentation structure with theory and code separation
-
-Added
------
-- Core genetic algorithm framework
-- Individual and population management classes
-- Selection, crossover, mutation, and replacement algorithms
-- Configuration system for genetic algorithm parameters
-- Base classes for extensible genetic algorithm implementation
 
 Features
 --------

--- a/mango_genetic/pyproject.toml
+++ b/mango_genetic/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.24.4,<2.0.0",
-    "mango[data]==0.3.0a8",
+    "mango==1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/mango_time_series/changelog.rst
+++ b/mango_time_series/changelog.rst
@@ -7,14 +7,14 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 ------------
 
 [1.0.1] - 2024-12-26
--------------------
+--------------------
 
 Added
 -----
 - Updated mango dependency version
 
 [1.0.0] - 2024-12-24
--------------------
+--------------------
 
 Added
 -----

--- a/mango_time_series/changelog.rst
+++ b/mango_time_series/changelog.rst
@@ -1,6 +1,3 @@
-Changelog
-=========
-
 All notable changes to the mango_time_series project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
@@ -9,16 +6,15 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ------------
 
+[1.0.1] - 2024-12-26
+-------------------
+
 Added
 -----
-- Enhanced time series analysis capabilities
-- Improved data processing and validation functions
-- Better integration with the mango ecosystem
+- Updated mango dependency version
 
-Changed
--------
-- Updated dependencies and package configuration
-- Enhanced test coverage and documentation
+[1.0.0] - 2024-12-24
+-------------------
 
 Added
 -----
@@ -30,6 +26,14 @@ Added
 - Heteroscedasticity analysis
 - Custom cross-validation for time series forecasting
 - Comprehensive logging and error handling
+- Enhanced time series analysis capabilities
+- Improved data processing and validation functions
+- Better integration with the mango ecosystem
+
+Changed
+-------
+- Updated dependencies and package configuration
+- Enhanced test coverage and documentation
 
 Features
 --------

--- a/mango_time_series/pyproject.toml
+++ b/mango_time_series/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "polars>=1.8.2,<2.0.0",
     "scipy>=1.10.1,<2.0.0",
     "statsmodels>=0.14.1,<1.0.0",
-    "mango[data]==0.3.0a8",
+    "mango==1.0.0",
     "scikit-learn>=1.6.1,<2.0.0",
     "pyarrow>=21.0.0,<22.0.0",
 ]


### PR DESCRIPTION
- The mango core module has been updated to version 1.0.0 with comprehensive migration documentation including multi-module project structure, uv package manager integration, and enhanced dependency management. **mango_dashboard remains pending as it depends on mango_time_series performing its update.mango_dashboard remains pending as it depends on mango_time_series performing its update.**
- This pull request addresses documentation structure issues and standardizes changelog formatting across all modules. The changes include removing the "Changelog" title from all module changelog files to prevent it from appearing in the documentation index, restructuring all changelogs to properly document version 1.0.0 releases and adding version 1.0.1 entries for dependency updates. 